### PR TITLE
fix: remove timestamp from logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,8 @@ import (
 )
 
 func main() {
+	log.SetFlags(0)
+
 	if len(os.Args) != 2 {
 		log.Fatalln("Wrong usage, expected either 'validate' or `validate-settings'")
 	}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,9 @@ import (
 )
 
 func main() {
+	// Since we use log.Fatal* functions to write to stderr and exit with a non-zero status code,
+	// we need to disable the default log prefix that includes the date and time, as it would
+	// be bubbled up to the message of the response returned to the caller.
 	log.SetFlags(0)
 
 	if len(os.Args) != 2 {


### PR DESCRIPTION
## Description

We use `log.Fatalf` to print to stderr and exit. The stderr message is then bubbled up as a policy rejection response to the user. 
We don't want the message to be polluted by timestamps or other log metadata, so setting the log flags to 0 is needed here.


Related to: https://github.com/kubewarden/policy-evaluator/pull/522